### PR TITLE
3 implement battery query by postcode range with capacity statistics

### DIFF
--- a/src/main/java/com/tanmoy/vpp/controller/BatteryController.java
+++ b/src/main/java/com/tanmoy/vpp/controller/BatteryController.java
@@ -1,6 +1,7 @@
 package com.tanmoy.vpp.controller;
 
 import com.tanmoy.vpp.dto.request.BatteryListRequest;
+import com.tanmoy.vpp.dto.response.BatterySearchResponseDto;
 import com.tanmoy.vpp.dto.response.SuccessResponseDto;
 import com.tanmoy.vpp.model.Battery;
 import com.tanmoy.vpp.service.BatteryService;
@@ -10,10 +11,7 @@ import org.apache.logging.log4j.Logger;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
 import java.util.stream.Collectors;
@@ -48,4 +46,24 @@ public class BatteryController {
         return ResponseEntity.status(HttpStatus.CREATED)
                 .body(new SuccessResponseDto("Saved " + batteryListRequest.getBatteries().size() + " batteries successfully."));
     }
+
+    @GetMapping("/search")
+    public ResponseEntity<BatterySearchResponseDto> getBatteriesByPostcodeRange(
+            @RequestParam int startPostcode,
+            @RequestParam int endPostcode,
+            @RequestParam(required = false) Integer minCapacity,
+            @RequestParam(required = false) Integer maxCapacity) {
+
+        logger.info("Process search batteries request: " +
+                "StartPostcode={}, EndPostcode={}: START", startPostcode, endPostcode);
+
+        BatterySearchResponseDto response = batteryService.getBatteriesByPostcodeRange(
+                startPostcode, endPostcode, minCapacity, maxCapacity);
+
+        logger.info("Process search batteries request: " +
+                "StartPostcode={}, EndPostcode={}: COMPLETE", startPostcode, endPostcode);
+
+        return ResponseEntity.ok(response);
+    }
+
 }

--- a/src/main/java/com/tanmoy/vpp/dto/response/BatterySearchResponseDto.java
+++ b/src/main/java/com/tanmoy/vpp/dto/response/BatterySearchResponseDto.java
@@ -1,0 +1,40 @@
+package com.tanmoy.vpp.dto.response;
+
+import java.util.List;
+
+public class BatterySearchResponseDto {
+
+    private List<String> batteryNames;
+    private long totalWattCapacity;
+    private double averageWattCapacity;
+
+    public BatterySearchResponseDto(List<String> batteryNames, long totalWattCapacity, double averageWattCapacity) {
+        this.batteryNames = batteryNames;
+        this.totalWattCapacity = totalWattCapacity;
+        this.averageWattCapacity = averageWattCapacity;
+    }
+
+    public List<String> getBatteryNames() {
+        return batteryNames;
+    }
+
+    public void setBatteryNames(List<String> batteryNames) {
+        this.batteryNames = batteryNames;
+    }
+
+    public long getTotalWattCapacity() {
+        return totalWattCapacity;
+    }
+
+    public void setTotalWattCapacity(long totalWattCapacity) {
+        this.totalWattCapacity = totalWattCapacity;
+    }
+
+    public double getAverageWattCapacity() {
+        return averageWattCapacity;
+    }
+
+    public void setAverageWattCapacity(double averageWattCapacity) {
+        this.averageWattCapacity = averageWattCapacity;
+    }
+}

--- a/src/main/java/com/tanmoy/vpp/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/tanmoy/vpp/exception/GlobalExceptionHandler.java
@@ -12,6 +12,7 @@ import org.springframework.validation.FieldError;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -56,6 +57,23 @@ public class GlobalExceptionHandler {
                 .body(new ErrorResponse("Invalid data"));
     }
 
+    @ExceptionHandler(InvalidRangeException.class)
+    public ResponseEntity<ErrorResponse> handleInvalidRange(InvalidRangeException ex) {
+        logger.error("Invalid range exception", ex);
+        return ResponseEntity
+                .status(HttpStatus.BAD_REQUEST)
+                .body(new ErrorResponse(ex.getMessage()));
+    }
+
+    @ExceptionHandler(MethodArgumentTypeMismatchException.class)
+    public ResponseEntity<ErrorResponse> handleTypeMismatch(MethodArgumentTypeMismatchException ex) {
+        logger.error("Type mismatch error", ex);
+        return ResponseEntity
+                .status(HttpStatus.BAD_REQUEST)
+                .body(new ErrorResponse(
+                        "Invalid input: " + ex.getName() + " should be of type " + ex.getRequiredType().getSimpleName()
+                ));
+    }
 
     @ExceptionHandler(Exception.class)
     public ResponseEntity<ErrorResponse> handleGenericException(Exception ex) {

--- a/src/main/java/com/tanmoy/vpp/exception/InvalidRangeException.java
+++ b/src/main/java/com/tanmoy/vpp/exception/InvalidRangeException.java
@@ -1,0 +1,8 @@
+package com.tanmoy.vpp.exception;
+
+public class InvalidRangeException extends RuntimeException {
+
+    public InvalidRangeException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/tanmoy/vpp/repository/BatteryRepository.java
+++ b/src/main/java/com/tanmoy/vpp/repository/BatteryRepository.java
@@ -2,9 +2,21 @@ package com.tanmoy.vpp.repository;
 
 import com.tanmoy.vpp.model.Battery;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
+import java.util.List;
 import java.util.UUID;
 
 public interface BatteryRepository extends JpaRepository<Battery, UUID> {
+
+    @Query("SELECT b FROM Battery b WHERE CAST(b.postcode AS int) BETWEEN :startPostcode AND :endPostcode "
+            + "AND (:minCapacity IS NULL OR b.capacity >= :minCapacity) "
+            + "AND (:maxCapacity IS NULL OR b.capacity <= :maxCapacity)")
+    List<Battery> findInRangeWithOptionalCapacity(@Param("startPostcode") int startPostcode,
+                                                  @Param("endPostcode") int endPostcode,
+                                                  @Param("minCapacity") Integer minCapacity,
+                                                  @Param("maxCapacity") Integer maxCapacity);
+
 
 }

--- a/src/main/java/com/tanmoy/vpp/service/BatteryService.java
+++ b/src/main/java/com/tanmoy/vpp/service/BatteryService.java
@@ -1,5 +1,6 @@
 package com.tanmoy.vpp.service;
 
+import com.tanmoy.vpp.dto.response.BatterySearchResponseDto;
 import com.tanmoy.vpp.model.Battery;
 
 import java.util.List;
@@ -7,4 +8,7 @@ import java.util.List;
 public interface BatteryService {
 
     void saveAll(List<Battery> batteries);
+
+    BatterySearchResponseDto getBatteriesByPostcodeRange(
+            int startPostcode, int endPostcode, Integer minCapacity, Integer maxCapacity);
 }

--- a/src/main/java/com/tanmoy/vpp/service/impl/BatteryServiceImpl.java
+++ b/src/main/java/com/tanmoy/vpp/service/impl/BatteryServiceImpl.java
@@ -1,5 +1,7 @@
 package com.tanmoy.vpp.service.impl;
 
+import com.tanmoy.vpp.dto.response.BatterySearchResponseDto;
+import com.tanmoy.vpp.exception.InvalidRangeException;
 import com.tanmoy.vpp.model.Battery;
 import com.tanmoy.vpp.repository.BatteryRepository;
 import com.tanmoy.vpp.service.BatteryService;
@@ -10,6 +12,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
+import java.util.stream.Collectors;
 
 @Service
 public class BatteryServiceImpl implements BatteryService {
@@ -33,4 +36,30 @@ public class BatteryServiceImpl implements BatteryService {
 
         logger.info("Saving batteries: Size={}: COMPLETE", batteries.size());
     }
+
+    public BatterySearchResponseDto getBatteriesByPostcodeRange(
+            int startPostcode, int endPostcode, Integer minCapacity, Integer maxCapacity) {
+
+        logger.info("Search batteries: StartPostcode={}, EndPostcode={}: START", startPostcode, endPostcode);
+
+        if (startPostcode > endPostcode) {
+            throw new InvalidRangeException("Start postcode must be less than or equal to end postcode");
+        }
+
+        List<Battery> batteries = batteryRepository.findInRangeWithOptionalCapacity(
+                startPostcode, endPostcode, minCapacity, maxCapacity);
+
+        List<String> names = batteries.stream()
+                .map(Battery::getName)
+                .sorted()
+                .collect(Collectors.toList());
+
+        long totalCapacity = batteries.stream().mapToLong(Battery::getCapacity).sum();
+        double averageCapacity = batteries.isEmpty() ? 0.0 : (double) totalCapacity / batteries.size();
+
+        logger.info("Search batteries: StartPostcode={}, EndPostcode={}: COMPLETE", startPostcode, endPostcode);
+
+        return new BatterySearchResponseDto(names, totalCapacity, averageCapacity);
+    }
+
 }

--- a/src/test/java/com/tanmoy/vpp/repository/BatteryRepositoryTest.java
+++ b/src/test/java/com/tanmoy/vpp/repository/BatteryRepositoryTest.java
@@ -1,6 +1,7 @@
 package com.tanmoy.vpp.repository;
 
 import com.tanmoy.vpp.model.Battery;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
@@ -17,6 +18,15 @@ public class BatteryRepositoryTest {
 
     @Autowired
     private BatteryRepository batteryRepository;
+
+    @BeforeEach
+    void setup() {
+        batteryRepository.saveAll(List.of(
+                new Battery("Alpha", "6000", 1000),
+                new Battery("Beta", "6001", 2000),
+                new Battery("Gamma", "6002", 3000)
+        ));
+    }
 
     @Test
     void shouldPersistBatteryEntity() {
@@ -57,5 +67,35 @@ public class BatteryRepositoryTest {
 
         assertThat(foundBattery).isPresent();
         assertThat(foundBattery.get().getName()).isEqualTo(battery.getName());
+    }
+
+    @Test
+    void shouldFindBatteriesWithinPostcodeRange() {
+        List<Battery> results = batteryRepository.findInRangeWithOptionalCapacity(
+                6000, 6002, null, null);
+        assertThat(results).hasSize(3);
+    }
+
+    @Test
+    void shouldFilterByMinCapacity() {
+        List<Battery> results = batteryRepository.findInRangeWithOptionalCapacity(
+                6000, 6002, 2000, null);
+        assertThat(results).hasSize(2);
+        assertThat(results).extracting("name").containsExactlyInAnyOrder("Beta", "Gamma");
+    }
+
+    @Test
+    void shouldFilterByMaxCapacity() {
+        List<Battery> results = batteryRepository.findInRangeWithOptionalCapacity(
+                6000, 6002, null, 2000);
+        assertThat(results).hasSize(2);
+        assertThat(results).extracting("name").containsExactlyInAnyOrder("Alpha", "Beta");
+    }
+
+    @Test
+    void shouldReturnEmptyWhenNoMatch() {
+        List<Battery> results = batteryRepository.findInRangeWithOptionalCapacity(
+                7000, 8000, null, null);
+        assertThat(results).isEmpty();
     }
 }

--- a/src/test/java/com/tanmoy/vpp/service/BatteryServiceImplTest.java
+++ b/src/test/java/com/tanmoy/vpp/service/BatteryServiceImplTest.java
@@ -1,5 +1,7 @@
 package com.tanmoy.vpp.service;
 
+import com.tanmoy.vpp.dto.response.BatterySearchResponseDto;
+import com.tanmoy.vpp.exception.InvalidRangeException;
 import com.tanmoy.vpp.model.Battery;
 import com.tanmoy.vpp.repository.BatteryRepository;
 import com.tanmoy.vpp.service.impl.BatteryServiceImpl;
@@ -12,9 +14,13 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.transaction.TransactionSystemException;
 
+import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.*;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
 
+import static org.assertj.core.api.AssertionsForInterfaceTypes.assertThat;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.Mockito.*;
@@ -99,6 +105,145 @@ class BatteryServiceImplTest {
         executorService.shutdown();
 
         verify(batteryRepository, times(numberOfConcurrentRequests)).saveAll(anyList());
+    }
+
+    @Test
+    void shouldReturnFilteredAndSortedBatteriesInRange() {
+
+        Battery battery1 = new Battery("Alpha", "6000", 1000);
+        Battery battery2 = new Battery("Beta", "6001", 2000);
+        Battery battery3 = new Battery("Gamma", "6002", 3000);
+
+        List<Battery> mockList = List.of(battery2, battery3, battery1);
+
+        when(batteryRepository.findInRangeWithOptionalCapacity(
+                6000, 6002, null, null)).thenReturn(mockList);
+
+        BatterySearchResponseDto response = batteryService.getBatteriesByPostcodeRange(
+                6000, 6002, null, null);
+
+        assertThat(response.getBatteryNames()).containsExactly("Alpha", "Beta", "Gamma");
+        assertThat(response.getTotalWattCapacity()).isEqualTo(6000);
+        assertThat(response.getAverageWattCapacity()).isEqualTo(2000.0);
+    }
+
+    @Test
+    void shouldApplyMinAndMaxCapacityFilter() {
+
+        Battery battery1 = new Battery("Alpha", "6100", 500);
+        Battery battery2 = new Battery("Beta", "6101", 1500);
+        Battery battery3 = new Battery("Gamma", "6102", 2500);
+
+        List<Battery> mockList = List.of(battery2, battery3);
+
+        when(batteryRepository.findInRangeWithOptionalCapacity(
+                6100, 6102, 1000, 3000)).thenReturn(mockList);
+
+        BatterySearchResponseDto response = batteryService.getBatteriesByPostcodeRange(
+                6100, 6102, 1000, 3000);
+
+        assertThat(response.getBatteryNames()).containsExactly("Beta", "Gamma");
+        assertThat(response.getTotalWattCapacity()).isEqualTo(4000);
+        assertThat(response.getAverageWattCapacity()).isEqualTo(2000.0);
+    }
+
+    @Test
+    void shouldReturnZeroStatsForNoMatches() {
+
+        when(batteryRepository.findInRangeWithOptionalCapacity(
+                7000, 7001, null, null)).thenReturn(Collections.emptyList());
+
+        BatterySearchResponseDto response = batteryService.getBatteriesByPostcodeRange(
+                7000, 7001, null, null);
+
+        assertThat(response.getBatteryNames()).isEmpty();
+        assertThat(response.getTotalWattCapacity()).isEqualTo(0);
+        assertThat(response.getAverageWattCapacity()).isEqualTo(0.0);
+    }
+
+    @Test
+    void shouldHandleNullCapacityFilters() {
+
+        Battery battery1 = new Battery("Alpha", "6000", 1000);
+        Battery battery2 = new Battery("Beta", "6001", 2000);
+
+        List<Battery> mockList = List.of(battery1, battery2);
+
+        when(batteryRepository.findInRangeWithOptionalCapacity(
+                6000, 6001, null, null)).thenReturn(mockList);
+
+        BatterySearchResponseDto response = batteryService.getBatteriesByPostcodeRange(
+                6000, 6001, null, null);
+
+        assertThat(response.getBatteryNames()).containsExactly("Alpha", "Beta");
+        assertThat(response.getTotalWattCapacity()).isEqualTo(3000);
+        assertThat(response.getAverageWattCapacity()).isEqualTo(1500.0);
+    }
+
+    @Test
+    void shouldHandleBoundaryPostcodeValues() {
+
+        Battery battery = new Battery("Boundary", "9999", 1000);
+
+        List<Battery> mockList = List.of(battery);
+
+        when(batteryRepository.findInRangeWithOptionalCapacity(
+                9999, 9999, null, null)).thenReturn(mockList);
+
+        BatterySearchResponseDto response = batteryService.getBatteriesByPostcodeRange(
+                9999, 9999, null, null);
+
+        assertThat(response.getBatteryNames()).containsExactly("Boundary");
+        assertThat(response.getTotalWattCapacity()).isEqualTo(1000);
+        assertThat(response.getAverageWattCapacity()).isEqualTo(1000.0);
+    }
+
+    @Test
+    void shouldHandleLargeResultSet() {
+
+        List<Battery> largeList = IntStream.range(0, 1000)
+                .mapToObj(i -> new Battery("Battery-" + i, "6000", 1000))
+                .collect(Collectors.toList());
+
+        when(batteryRepository.findInRangeWithOptionalCapacity(
+                6000, 6000, null, null)).thenReturn(largeList);
+
+        long startTime = System.currentTimeMillis();
+
+        BatterySearchResponseDto response = batteryService.getBatteriesByPostcodeRange(
+                6000, 6000, null, null);
+
+        long duration = System.currentTimeMillis() - startTime;
+
+        assertThat(duration).isLessThan(1000);
+        assertThat(response.getBatteryNames()).hasSize(1000);
+        assertThat(response.getTotalWattCapacity()).isEqualTo(1000000);
+        assertThat(response.getAverageWattCapacity()).isEqualTo(1000.0);
+    }
+
+    @Test
+    void shouldHandleZeroCapacityValues() {
+
+        Battery battery = new Battery("Zero", "6000", 0);
+
+        List<Battery> mockList = List.of(battery);
+
+        when(batteryRepository.findInRangeWithOptionalCapacity(
+                6000, 6000, null, null)).thenReturn(mockList);
+
+        BatterySearchResponseDto response = batteryService.getBatteriesByPostcodeRange(
+                6000, 6000, null, null);
+
+        assertThat(response.getBatteryNames()).containsExactly("Zero");
+        assertThat(response.getTotalWattCapacity()).isEqualTo(0);
+        assertThat(response.getAverageWattCapacity()).isEqualTo(0.0);
+    }
+
+    @Test
+    void shouldThrowInvalidRangeExceptionWhenStartGreaterThanEnd() {
+        assertThrows(InvalidRangeException.class, () -> {
+            batteryService.getBatteriesByPostcodeRange(7002, 7001, null, null);
+        });
     }
 
 }


### PR DESCRIPTION
## Summary
Implements GET **/api/batteries/search** to retrieve batteries within a given postcode range, with optional filtering by minimum and maximum watt capacity. It returns battery names (sorted alphabetically), total capacity, and average capacity.


## What’s Included
GET endpoint: **/api/batteries/search**


## Query Parameters:

>startPostcode (required)

>endPostcode (required)

>minCapacity (optional)

>maxCapacity (optional)


## Response
{
              "batteryNames": ["Alpha", "Beta"],
              "totalWattCapacity": 3000,
              "averageWattCapacity": 1500.0
}

## Tests
✅ Unit tests for controller and service (valid, invalid, edge cases)

✅ Integration test using MockMvc with real H2 in-memory DB
