### PR TITLE
5 improve postcode handling for battery insertion and range queries

### DIFF
--- a/src/main/java/com/tanmoy/vpp/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/tanmoy/vpp/exception/GlobalExceptionHandler.java
@@ -65,6 +65,12 @@ public class GlobalExceptionHandler {
                 .body(new ErrorResponse(ex.getMessage()));
     }
 
+    @ExceptionHandler(IllegalArgumentException.class)
+    public ResponseEntity<ErrorResponse> handleIllegalArgument(IllegalArgumentException ex) {
+        ErrorResponse error = new ErrorResponse(ex.getMessage());
+        return ResponseEntity.badRequest().body(error);
+    }
+
     @ExceptionHandler(MethodArgumentTypeMismatchException.class)
     public ResponseEntity<ErrorResponse> handleTypeMismatch(MethodArgumentTypeMismatchException ex) {
         logger.error("Type mismatch error", ex);

--- a/src/main/java/com/tanmoy/vpp/model/Battery.java
+++ b/src/main/java/com/tanmoy/vpp/model/Battery.java
@@ -27,11 +27,10 @@ public class Battery {
 
     public Battery() {}
 
-    private Battery(String name, String postcode, int postcodeNumeric, int capacity) {
+    private Battery(String name, String postcode, int capacity) {
         this.name = name;
-        this.postcode = postcode;
-        this.postcodeNumeric = postcodeNumeric;
         this.capacity = capacity;
+        setPostcode(postcode);
     }
 
     public UUID getId() {
@@ -54,10 +53,6 @@ public class Battery {
         return postcode;
     }
 
-    public void setPostcode(String postcode) {
-        this.postcode = postcode;
-    }
-
     public Integer getCapacity() {
         return capacity;
     }
@@ -70,11 +65,19 @@ public class Battery {
         return postcodeNumeric;
     }
 
-    public void setPostcodeNumeric(Integer postcodeNumeric) {
-        this.postcodeNumeric = postcodeNumeric;
+    private void setPostcode(String postcode) {
+        if (postcode == null || !postcode.matches("^\\d{4,10}$")) {
+            throw new IllegalArgumentException("Postcode must be a numeric string with 4 to 10 digits");
+        }
+        try {
+            this.postcode = postcode;
+            this.postcodeNumeric = Integer.parseInt(postcode);
+        } catch (NumberFormatException e) {
+            throw new IllegalArgumentException("Postcode must be a numeric string with 4 to 10 digits", e);
+        }
     }
 
     public static Battery of(String name, String postcode, int capacity) {
-        return new Battery(name, postcode, Integer.parseInt(postcode), capacity);
+        return new Battery(name, postcode, capacity);
     }
 }

--- a/src/test/java/com/tanmoy/vpp/repository/BatteryRepositoryTest.java
+++ b/src/test/java/com/tanmoy/vpp/repository/BatteryRepositoryTest.java
@@ -11,6 +11,8 @@ import java.util.List;
 import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 @DataJpaTest
 @AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.ANY)
@@ -113,6 +115,21 @@ public class BatteryRepositoryTest {
         List<Battery> results = batteryRepository.findInRangeWithOptionalCapacity(
                 820, 820, null, null);
         assertThat(results).extracting("name").containsExactly("ZeroLead");
+    }
+
+    @Test
+    void shouldThrowExceptionForInvalidPostcode() {
+        assertThrows(IllegalArgumentException.class, () -> {
+            Battery.of("BadBattery", "60AB", 1000);
+        });
+    }
+
+    @Test
+    void shouldThrowExceptionForShortPostcode() {
+        IllegalArgumentException ex = assertThrows(IllegalArgumentException.class, () ->
+                Battery.of("ShortPostcode", "123", 1000)
+        );
+        assertEquals("Postcode must be a numeric string with 4 to 10 digits", ex.getMessage());
     }
 
 }


### PR DESCRIPTION
Validate postcode format in the Battery entity constructor and throw IllegalArgumentException for invalid inputs. Also add unit tests for postcode validation and error handling.

