### PR TITLE
test: switch from H2 to PostgreSQL using Testcontainers

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -27,7 +27,8 @@ dependencies {
 	implementation 'org.flywaydb:flyway-database-postgresql'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
-	testImplementation 'com.h2database:h2'
+	testImplementation 'org.testcontainers:junit-jupiter'
+	testImplementation 'org.testcontainers:postgresql'
 }
 
 configurations {

--- a/src/test/java/com/tanmoy/vpp/BasePostgresTest.java
+++ b/src/test/java/com/tanmoy/vpp/BasePostgresTest.java
@@ -1,0 +1,25 @@
+package com.tanmoy.vpp;
+
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.testcontainers.containers.PostgreSQLContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+@Testcontainers
+public abstract class BasePostgresTest {
+
+    @Container
+    static final PostgreSQLContainer<?> postgres = new PostgreSQLContainer<>("postgres:15")
+            .withDatabaseName("vpp_test")
+            .withUsername("testuser")
+            .withPassword("testpass");
+
+    @DynamicPropertySource
+    static void registerPostgresProperties(DynamicPropertyRegistry registry) {
+        registry.add("spring.datasource.url", postgres::getJdbcUrl);
+        registry.add("spring.datasource.username", postgres::getUsername);
+        registry.add("spring.datasource.password", postgres::getPassword);
+        registry.add("spring.datasource.driver-class-name", () -> "org.postgresql.Driver");
+    }
+}

--- a/src/test/java/com/tanmoy/vpp/VppRestApiApplicationTests.java
+++ b/src/test/java/com/tanmoy/vpp/VppRestApiApplicationTests.java
@@ -4,7 +4,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
 
 @SpringBootTest
-class VppRestApiApplicationTests {
+class VppRestApiApplicationTests extends BasePostgresTest {
 
 	@Test
 	void contextLoads() {

--- a/src/test/java/com/tanmoy/vpp/integration/BatteryControllerIntegrationTest.java
+++ b/src/test/java/com/tanmoy/vpp/integration/BatteryControllerIntegrationTest.java
@@ -1,6 +1,7 @@
 package com.tanmoy.vpp.integration;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.tanmoy.vpp.BasePostgresTest;
 import com.tanmoy.vpp.dto.request.BatteryListRequest;
 import com.tanmoy.vpp.dto.request.BatteryRequestDto;
 import com.tanmoy.vpp.model.Battery;
@@ -30,7 +31,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 @SpringBootTest
 @AutoConfigureMockMvc
 @Transactional
-public class BatteryControllerIntegrationTest {
+public class BatteryControllerIntegrationTest extends BasePostgresTest {
 
     @Autowired
     private MockMvc mockMvc;

--- a/src/test/java/com/tanmoy/vpp/repository/BatteryRepositoryTest.java
+++ b/src/test/java/com/tanmoy/vpp/repository/BatteryRepositoryTest.java
@@ -1,5 +1,6 @@
 package com.tanmoy.vpp.repository;
 
+import com.tanmoy.vpp.BasePostgresTest;
 import com.tanmoy.vpp.model.Battery;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -15,8 +16,8 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 @DataJpaTest
-@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.ANY)
-public class BatteryRepositoryTest {
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+public class BatteryRepositoryTest extends BasePostgresTest {
 
     @Autowired
     private BatteryRepository batteryRepository;

--- a/src/test/resources/application.properties
+++ b/src/test/resources/application.properties
@@ -1,8 +1,5 @@
-spring.datasource.url=jdbc:h2:mem:testdb;DB_CLOSE_DELAY=-1;MODE=PostgreSQL
-spring.datasource.driver-class-name=org.h2.Driver
-spring.datasource.username=sa
-spring.datasource.password=
 
+# Spring Boot Test Configuration
 spring.jpa.hibernate.ddl-auto=create-drop
 spring.flyway.enabled=false
 


### PR DESCRIPTION
- Removed H2 dependency from test scope
- Added PostgreSQL Testcontainers for realistic DB testing
- Applied dynamic DB property injection via @DynamicPropertySource